### PR TITLE
Release GIL in device_get_capture

### DIFF
--- a/pyk4a/pyk4a.cpp
+++ b/pyk4a/pyk4a.cpp
@@ -141,7 +141,10 @@ extern "C" {
             k4a_capture_release(devices[device_id].capture);
         }
         k4a_capture_create(&devices[device_id].capture);
-        k4a_wait_result_t result = k4a_device_get_capture(devices[device_id].device, &devices[device_id].capture, timeout);
+        k4a_wait_result_t result;
+        Py_BEGIN_ALLOW_THREADS
+        result = k4a_device_get_capture(devices[device_id].device, &devices[device_id].capture, timeout);
+        Py_END_ALLOW_THREADS
         return Py_BuildValue("I", result);
     }
 

--- a/pyk4a/pyk4a.py
+++ b/pyk4a/pyk4a.py
@@ -24,9 +24,10 @@ class K4ATimeoutException(K4AException):
 class PyK4A:
     TIMEOUT_WAIT_INFINITE = -1
 
-    def __init__(self, config=Config(), device_id=0):
+    def __init__(self, config=Config(), device_id=0, thread_safe: bool = True):
         self._device_id = device_id
         self._config = config
+        self._thread_safe = thread_safe
         self.is_running = False
 
     def __del__(self):
@@ -55,7 +56,8 @@ class PyK4A:
         self._verify_error(res)
 
     def _device_open(self):
-        res = k4a_module.device_open(self._device_id)
+        thread_safe = 1 if self._thread_safe else 0
+        res = k4a_module.device_open(self._device_id, thread_safe)
         self._verify_error(res)
 
     def _device_close(self):


### PR DESCRIPTION
if you read captures in threads  app performance will be decreased due GIL locking.
This PR release GIL inside `C` functions. 